### PR TITLE
added 'defer's where necessary to prevent race condition

### DIFF
--- a/frontend/include/schedule.html
+++ b/frontend/include/schedule.html
@@ -19,4 +19,4 @@
 		<div id="calendar-table"></div>
 	</div>
 </div>
-<script src="/frontend/schedule/calendar.js" type="module"></script>
+<script defer src="/frontend/schedule/calendar.js" type="module"></script>

--- a/frontend/include/timeline.html
+++ b/frontend/include/timeline.html
@@ -27,5 +27,5 @@
 	<div class="float left" id="left_time"></div>
 	<div class="float right" id="right_time"></div>
 	<br />
-	<script src="/frontend/global/timeline.js" type="module"></script>
+	<script defer src="/frontend/global/timeline.js" type="module"></script>
 </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,7 +13,7 @@
 </head>
 
 <body class="background-color">
-	<script src="index.js" type="module"></script>
+	<script defer src="index.js" type="module"></script>
 	<include src="include/navbar.html"></include>
 	<div id="wrapper" class="background-color">
 		<div class="big block text-center content">
@@ -21,8 +21,7 @@
 				<div class="progress">
 					<svg class="progress-ring">
 						<circle class="progress-ring__circle" stroke="currentColor" fill="transparent" />
-						<circle class="progress-ring__border" stroke="currentColor" fill="transparent"
-							strokewidth="4" />
+						<circle class="progress-ring__border" stroke="currentColor" fill="transparent" strokewidth="4" />
 					</svg>
 				</div>
 				<span class="text-wrapper">{NAME} ends at <b>{END}</b> (in <b>{END_IN}</b>).

--- a/frontend/timeline/index.html
+++ b/frontend/timeline/index.html
@@ -8,7 +8,7 @@
 	<title>ETHSBell NG</title>
 	<link rel="stylesheet" href="../timeline/index.css" />
 	<include src="include/prelude.html"></include>
-	<script defer async type="module" src="../timeline/index.js" type="module"></script>
+	<script defer type="module" src="../timeline/index.js" type="module"></script>
 	<script defer src="../global/autohide_nav.js" type="module"></script>
 	<meta http-equiv="Content-Security-Policy" content="default-src 'self';" />
 </head>


### PR DESCRIPTION
I was having an issue where scripts would sometimes fail because getel wasn't being defined early enough. I added 'defer' attributes to <script> tags that depend on getel so they will load afterwards.

This could also be improved by moving getel higher in helpers.js, lmk if you would rather I do that.

I'm able to replicate the issue on Chrome and Firefox, but it's very intermittent.