### PR TITLE
Added an extra binary target that produces a simple command-line ETHSBell client.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,7 +52,7 @@
 		"wasm",
 		"wildkit"
 	],
-	"rust-analyzer.cargo.features": ["ws"],
+	"rust-analyzer.cargo.features": "all",
 	"rust-analyzer.updates.channel": "nightly",
 	"nixEnvSelector.suggestion": false,
 	"rcover.testCommand": "cargo test --features ws",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +239,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "cookie"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,7 +339,7 @@ dependencies = [
  "ident_case",
  "proc-macro2 1.0.36",
  "quote 1.0.14",
- "strsim",
+ "strsim 0.9.3",
  "syn 1.0.86",
 ]
 
@@ -413,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "ethsbell-rewrite"
-version = "2.0.27"
+version = "2.1.0"
 dependencies = [
  "base64 0.13.0",
  "chrono",
@@ -429,6 +453,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
+ "structopt",
  "subprocess",
  "thiserror",
  "urlencoding",
@@ -657,6 +682,15 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1349,6 +1383,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.86",
+ "version_check 0.9.4",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "version_check 0.9.4",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,9 +1893,39 @@ checksum = "3015a7d0a5fd5105c91c3710d42f9ccf0abfb287d62206484dcc67f9569a6483"
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.86",
+]
 
 [[package]]
 name = "subprocess"
@@ -1910,6 +1998,15 @@ dependencies = [
  "slug",
  "unic-segment",
  "url 1.7.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -2137,6 +2234,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,6 +2301,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rocket_prometheus = {git = "https://github.com/chromezoneeths/rocket_prometheus"
 rocket_okapi = {version = "0.6.0-alpha-1", optional = true}
 schemars = {version = "0.8.3", features = ["chrono"], optional = true}
 okapi = { version = "0.5.0-alpha-1", features = ["derive_json_schema"], optional = true }
+structopt = { version = "0.3.26", optional = true }
 
 [build-dependencies]
 subprocess = "*"
@@ -42,7 +43,13 @@ name = "bell_mkschema"
 required-features = ["ws"]
 path = "src/bin/bell_mkschema.rs"
 
+[[bin]]
+name = "bell_cli"
+required-features = ["cli"]
+path = "src/bin/bell_cli.rs"
+
 [features]
 default = ["ws"]
 ws = ["rocket", "rocket_contrib", "pull", "rocket_okapi", "schemars", "okapi", "rocket_prometheus"]
 pull = ["reqwest"]
+cli = ["structopt", "reqwest"]

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -1,0 +1,6 @@
+/// Type aliases for API V1
+pub mod v1 {
+	use crate::schedule::Period;
+	/// This is the type of the data returned by /api/v1/today/now/near.
+	pub type NearbyPeriods = (Option<Period>, Vec<Period>, Option<Period>);
+}

--- a/src/api/v1.rs
+++ b/src/api/v1.rs
@@ -2,6 +2,7 @@
 
 use super::OurError;
 use crate::{
+	aliases::v1::NearbyPeriods,
 	ical,
 	ical::IcalResponder,
 	login::Authenticated,
@@ -295,7 +296,7 @@ fn today_now(schedule: State<Arc<RwLock<Schedule>>>, timestamp: Option<i64>) -> 
 fn today_around_now(
 	schedule: State<Arc<RwLock<Schedule>>>,
 	timestamp: Option<i64>,
-) -> Json<(Option<Period>, Vec<Period>, Option<Period>)> {
+) -> Json<NearbyPeriods> {
 	Schedule::update_if_needed_async(schedule.clone());
 	let now = match timestamp {
 		None => Local::now(),

--- a/src/bin/bell_cli.rs
+++ b/src/bin/bell_cli.rs
@@ -1,0 +1,115 @@
+use chrono::{DateTime, Duration, Local};
+use ethsbell_rewrite::{aliases::v1::NearbyPeriods, schedule::Period};
+use structopt::StructOpt;
+
+/// Macro that prints only if the ugliness value is below the threshold
+macro_rules! println_l {
+	($q:ident, $t:expr, $($arg:tt)*) => {
+		if $q < $t {
+			println!($($arg)*);
+		}
+	};
+}
+
+#[derive(StructOpt)]
+pub struct Opt {
+	/// Set the ETHSBell server URL to use.
+	#[structopt(long, default_value = "https://ethsbell.app/")]
+	pub server: String,
+	/// Set the "fake date" used in the API request when applicable.
+	#[structopt(long)]
+	pub fake_date: Option<DateTime<Local>>,
+	/// Quietness of the output. Accepts up to `-qqqq`, at which point the output will just be unformatted json.
+	#[structopt(short, parse(from_occurrences))]
+	pub quietness: u64,
+}
+
+fn main() {
+	let args = Opt::from_args();
+	let response: NearbyPeriods = {
+		let response_text =
+			reqwest::blocking::get(format!("{}/api/v1/today/now/near", args.server))
+				.and_then(|v| v.text())
+				.expect("Failed to get data from ETHSBell");
+
+		if args.quietness >= 4 {
+			println!("{}", response_text);
+			return;
+		}
+
+		serde_json::from_str(&response_text).expect("Failed to parse ETHSBell data")
+	};
+
+	if args.quietness >= 3 {
+		println!(
+			"{}",
+			serde_json::to_string_pretty(&response).expect("failed to beautify")
+		);
+		return;
+	}
+
+	let show_period = |q: u64, n: u8, p: &Period| {
+		let period_type = match n {
+			0 => "Last",
+			1 => "Current",
+			2 => "Next",
+			_ => unreachable!(),
+		};
+		let now = Local::now().time();
+
+		println!("=== {} Period ===", period_type);
+		println!("Name: {}", p.friendly_name);
+		let start_delta = p.start - now;
+		if start_delta < Duration::zero() {
+			println_l!(q, 2, "Started {} ago", ftime(start_delta))
+		} else {
+			println_l!(q, 2, "Starts {} from now", ftime(start_delta))
+		}
+		println_l!(q, 1, "{} long in total", ftime(p.end - p.start));
+		println_l!(q, 1, "Period is {:?}", p.kind);
+
+		let end_delta = p.end - now;
+		if end_delta < Duration::zero() {
+			println_l!(q, 2, "Ended {} ago", ftime(end_delta))
+		} else {
+			println_l!(q, 2, "Ends {} from now", ftime(end_delta))
+		}
+		println!()
+	};
+	let q = args.quietness;
+	if let Some(period) = &response.0 {
+		show_period(q, 0, period);
+	}
+
+	for i in response.1.iter() {
+		show_period(q, 1, i);
+	}
+
+	if let Some(period) = &response.2 {
+		show_period(q, 2, period);
+	} else {
+		println_l!(q, 2, "=== No Next Period ===")
+	}
+}
+
+fn ftime(t: Duration) -> String {
+	let t = if t < chrono::Duration::zero() {
+		t * -1
+	} else {
+		t
+	};
+	if t.num_hours().abs() > 0 {
+		format!(
+			"{}h{}m",
+			t.num_hours(),
+			(t.num_minutes() - (t.num_hours() * 60))
+		)
+	} else if (t.num_minutes() - (t.num_hours() * 60)) > 0 {
+		format!("{}m{}s", t.num_minutes(), t.num_seconds())
+	} else {
+		format!(
+			"{}s",
+			t.num_seconds() - (t.num_minutes() * 60) - (t.num_hours() * 60 * 60)
+		)
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,5 +26,8 @@ pub use locks::SpecLock;
 pub mod frontend;
 pub mod schedule;
 
+/// Contains type aliases which may be useful to those consuming ETHSBell as a library
+pub mod aliases;
+
 /// Re-export things from serde.
 pub use serde_json::from_str;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 pub use locks::SpecLock;
 use schedule::{get_schedule_from_config, Schedule};
 
+mod aliases;
 #[cfg(feature = "ws")]
 mod api;
 mod frontend;

--- a/src/schedule/schedule_inner.rs
+++ b/src/schedule/schedule_inner.rs
@@ -5,9 +5,9 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::{env, fs};
 
+use std::path::Path;
 #[cfg(feature = "pull")]
 use std::{
-	path::Path,
 	sync::{Arc, RwLock},
 	thread,
 };


### PR DESCRIPTION
ETHSBell's API is so simple you could probably make a client for it in a shell script, but I thought it would be nice to provide an official one. All it does right now is print out a processed version of /api/v1/today/now/near's output.

To build it, run `cargo build --release --no-default-features --features cli --bin bell_cli`, or to install it, run `cargo install --path . --features cli --no-default-features --bin bell_cli`.