### PR TITLE
Fix literal funkiness

### DIFF
--- a/src/schedule/event.rs
+++ b/src/schedule/event.rs
@@ -60,8 +60,11 @@ pub fn ical_to_ours(schedule: &mut Schedule, data: &[IcalEvent]) {
 					.collect::<String>();
 				let result = serde_json::from_str::<ScheduleType>(&json);
 				if result.is_ok() {
-					let ev = Event::ScheduleLiteral(json);
-					if !date.contains(&ev) {
+					let ev = Event::ScheduleLiteral(json.clone());
+					if !date.iter().any(|v| match v {
+						Event::ScheduleLiteral(e) => e == &json,
+						_ => false,
+					}) {
 						date.push(ev);
 					}
 					return;

--- a/src/schedule/event.rs
+++ b/src/schedule/event.rs
@@ -60,7 +60,10 @@ pub fn ical_to_ours(schedule: &mut Schedule, data: &[IcalEvent]) {
 					.collect::<String>();
 				let result = serde_json::from_str::<ScheduleType>(&json);
 				if result.is_ok() {
-					date.push(Event::ScheduleLiteral(json));
+					let ev = Event::ScheduleLiteral(json);
+					if !date.contains(&ev) {
+						date.push(ev);
+					}
 					return;
 				} else {
 					println!("Error parsing schedule literal: {:?}", result.unwrap_err())

--- a/src/schedule/event.rs
+++ b/src/schedule/event.rs
@@ -61,10 +61,7 @@ pub fn ical_to_ours(schedule: &mut Schedule, data: &[IcalEvent]) {
 				let result = serde_json::from_str::<ScheduleType>(&json);
 				if result.is_ok() {
 					let ev = Event::ScheduleLiteral(json.clone());
-					if !date.iter().any(|v| match v {
-						Event::ScheduleLiteral(e) => e == &json,
-						_ => false,
-					}) {
+					if !date.contains(&Event::ScheduleLiteral(json.clone())) {
 						date.push(ev);
 					}
 					return;
@@ -128,10 +125,10 @@ pub fn ical_to_ours(schedule: &mut Schedule, data: &[IcalEvent]) {
 							if let Ok(r) = result {
 								// Merge partial schedule into original
 								merge(&mut json, &r);
-
-								date.push(Event::ScheduleLiteral(
-									serde_json::to_string(&json).unwrap(),
-								));
+								let json = serde_json::to_string(&json).unwrap();
+								if !date.contains(&Event::ScheduleLiteral(json.clone())) {
+									date.push(Event::ScheduleLiteral(json));
+								}
 								return;
 							} else {
 								println!(


### PR DESCRIPTION
Closes #102.

Adds a `force_update` endpoint to test refresh behavior in the future, and adds a check when refreshing to ensure that an identical schedule literal does not already exist on a given day.