### PR TITLE
API access when used as a library, support for compiling to WASM.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ version = "2.1.0"
 dependencies = [
  "base64 0.13.0",
  "chrono",
+ "getrandom",
  "okapi",
  "rand",
  "regex",
@@ -621,13 +622,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -950,9 +953,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "lock_api"
@@ -2036,7 +2039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
@@ -2346,6 +2349,12 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ rocket_okapi = {version = "0.6.0-alpha-1", optional = true}
 schemars = {version = "0.8.3", features = ["chrono"], optional = true}
 okapi = { version = "0.5.0-alpha-1", features = ["derive_json_schema"], optional = true }
 structopt = { version = "0.3.26", optional = true }
+# Required to allow ical generation to compile for WASM
+getrandom = {version = "0.2.8", optional = true}
 
 [build-dependencies]
 subprocess = "*"
@@ -51,5 +53,6 @@ path = "src/bin/bell_cli.rs"
 [features]
 default = ["ws"]
 ws = ["rocket", "rocket_contrib", "pull", "rocket_okapi", "schemars", "okapi", "rocket_prometheus"]
+wasm = ["getrandom/js"]
 pull = ["reqwest"]
 cli = ["structopt", "reqwest"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ This is a rewrite of ETHSBell in Rust. It features...
 -   Runtime-less deployment.
 -   Native performance.
 -   Rust library for client-side processing.
-    -   Never mind, still can't run in WASM.
 
 _Psst! If you're feeling really crafty, you could even self-host this and use it to structure your free time! For example, you could add an extra "class period" and designate it as homework time._
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,23 +1,29 @@
 //! Defines backend behavior.
 
+#[cfg(feature = "ws")]
 use rocket::{
 	fairing::{Fairing, Info, Kind},
 	http::Status,
 	response::{status::BadRequest, Responder},
 	Response,
 };
+#[cfg(feature = "ws")]
 use rocket_okapi::{
 	response::OpenApiResponder,
 	swagger_ui::{make_swagger_ui, SwaggerUIConfig},
 };
 
+#[cfg(feature = "ws")]
 use crate::login::WantsBasicAuth;
+#[cfg(feature = "ws")]
 pub mod legacy;
 pub mod v1;
 
 /// This struct is used as a Rocket Fairing and adds our API endpoints.
+#[cfg(feature = "ws")]
 pub struct ApiFairing;
 
+#[cfg(feature = "ws")]
 impl Fairing for ApiFairing {
 	fn info(&self) -> rocket::fairing::Info {
 		Info {
@@ -48,26 +54,29 @@ impl Fairing for ApiFairing {
 	}
 }
 
+#[cfg(feature = "ws")]
 #[catch(401)]
 fn wants_auth() -> WantsBasicAuth {
 	WantsBasicAuth
 }
 
 /// This defines how we convert Errors into Responses
-#[derive(thiserror::Error, Debug, JsonSchema)]
+#[cfg_attr(feature = "ws", derive(JsonSchema))]
+#[derive(thiserror::Error, Debug)]
 #[allow(missing_docs)]
 pub enum OurError {
 	#[error("Error trying to interpret date/time string; try YYYY-MM-DD or HH:MM:SS")]
-	#[schemars(skip)]
+	#[cfg_attr(feature = "ws", schemars(skip))]
 	BadString(#[from] chrono::ParseError),
 	#[error("Error trying to access a file")]
-	#[schemars(skip)]
+	#[cfg_attr(feature = "ws", schemars(skip))]
 	IOError(#[from] std::io::Error),
 	#[error("Error trying to transform some data")]
-	#[schemars(skip)]
+	#[cfg_attr(feature = "ws", schemars(skip))]
 	SerdeError(#[from] serde_json::Error),
 }
 
+#[cfg(feature = "ws")]
 impl<'r> Responder<'r> for OurError {
 	fn respond_to(self, request: &rocket::Request) -> rocket::response::Result<'r> {
 		Response::build_from(self.to_string().respond_to(request).unwrap())
@@ -80,10 +89,37 @@ impl<'r> Responder<'r> for OurError {
 	}
 }
 
+#[cfg(feature = "ws")]
 impl<'r> OpenApiResponder<'r> for OurError {
 	fn responses(
 		gen: &mut rocket_okapi::gen::OpenApiGenerator,
 	) -> rocket_okapi::Result<okapi::openapi3::Responses> {
 		BadRequest::<()>::responses(gen)
+	}
+}
+
+/// Dummy state struct for library use
+#[cfg(not(feature = "ws"))]
+pub struct State<T>(T);
+
+#[cfg(not(feature = "ws"))]
+impl<T> std::ops::Deref for State<T> {
+	type Target = T;
+
+	fn deref(&self) -> &T {
+		&self.0
+	}
+}
+
+/// Dummy json struct for library use
+#[cfg(not(feature = "ws"))]
+pub struct Json<T>(T);
+
+#[cfg(not(feature = "ws"))]
+impl<T> std::ops::Deref for Json<T> {
+	type Target = T;
+
+	fn deref(&self) -> &T {
+		&self.0
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,13 +10,11 @@ extern crate rocket;
 #[macro_use]
 extern crate rocket_okapi;
 
-#[cfg(feature = "ws")]
 pub mod api;
 pub mod ical;
 pub mod impls;
 #[cfg(feature = "ws")]
 pub mod locks;
-#[cfg(feature = "ws")]
 pub mod login;
 #[cfg(feature = "ws")]
 pub mod rocket_builder;

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,11 +1,17 @@
 //! This file defines our authentication behavior for the admin editor.
+
+#[cfg(feature = "ws")]
 use rocket::response::Response;
+#[cfg(feature = "ws")]
 use rocket::{http::Status, request::FromRequest, response::Responder, Outcome};
+#[cfg(feature = "ws")]
 use std::env;
+#[cfg(feature = "ws")]
 use std::io::Cursor;
 /// This struct is used as a request guard to require authentication.
 pub struct Authenticated;
 
+#[cfg(feature = "ws")]
 impl<'a, 'r> FromRequest<'a, 'r> for Authenticated {
 	type Error = WantsBasicAuth;
 
@@ -39,6 +45,7 @@ impl<'a, 'r> FromRequest<'a, 'r> for Authenticated {
 #[derive(Debug)]
 pub struct WantsBasicAuth;
 
+#[cfg(feature = "ws")]
 impl<'r> Responder<'r> for WantsBasicAuth {
 	fn respond_to(self, _request: &rocket::Request) -> rocket::response::Result<'r> {
 		Response::build()

--- a/src/schedule/schedule_inner.rs
+++ b/src/schedule/schedule_inner.rs
@@ -6,11 +6,9 @@ use std::convert::TryInto;
 use std::{env, fs};
 
 use std::path::Path;
-#[cfg(feature = "pull")]
-use std::{
-	sync::{Arc, RwLock},
-	thread,
-};
+use std::sync::{Arc, RwLock};
+#[cfg(feature = "ws")]
+use std::thread;
 
 #[cfg(feature = "pull")]
 use super::{ical_to_ours, IcalEvent};
@@ -63,6 +61,9 @@ impl Schedule {
 			thread::spawn(|| Schedule::update_async(schedule));
 		}
 	}
+	/// Dummy function to allow compiling without pull.
+	#[cfg(not(feature = "pull"))]
+	pub fn update_if_needed_async(_schedule: Arc<RwLock<Schedule>>) {}
 	/// Updates a schedule, locking minimally.
 	#[cfg(feature = "pull")]
 	pub fn update_async(schedule: Arc<RwLock<Schedule>>) {


### PR DESCRIPTION
I added more granular feature gating for the ws flag. Now, API endpoints are still accessible when this feature is disabled, allowing more complete use of ETHSBell as a library. I also made a small tweak to allow ETHSBell to compile for WASM with the ws feature.

We still use the blocking version of reqwest, so the pull feature flag is incompatible with wasm builds.